### PR TITLE
Remove trailing white spaces from script files + fix code/output boxes

### DIFF
--- a/asciidocs/awsbatch.adoc
+++ b/asciidocs/awsbatch.adoc
@@ -47,9 +47,10 @@ TIP: The best practice is to keep this setting as a separate
 https://www.nextflow.io/docs/latest/config.html#config-profiles[profile] in your
 workflow config file. This allows the execution with a simple command.
 
-```
+[cmd]
+----
 nextflow run <my pipeline> -profile my-batch-profile
-```
+----
 
 The complete details describing AWS Batch deployment are available at https://www.nextflow.io/docs/latest/awscloud.html#aws-batch[this link].
 
@@ -99,24 +100,26 @@ happens in the container scratch storage). Nextflow will still report an error i
 
 EBS volumes (or other supported storage) can be mounted in the job container using the following configuration snippet:
 
-```
+[source,config,linenums]
+----
 aws {
   batch {
       volumes = '/some/path'
   }
 }
-```
+----
 
 Multiple volumes can be specified using comma-separated paths. The usual Docker volume mount syntax can be used to define complex volumes for which the container paths are different from the host paths or to specify a read-only option:
 
-```
+[source,config,linenums]
+----
 aws {
   region = 'eu-west-1'
   batch {
       volumes = ['/tmp', '/host/path:/mnt/path:ro']
   }
 }
-```
+----
 
 IMPORTANT:
 
@@ -134,11 +137,12 @@ However, you may still need to specify a custom Job Definition to provide fine-g
 To use your own job definition in a Nextflow workflow, use it in place of the container image name by
 adding the `job-definition://` string as a prefix. For example:
 
-```
+[source,nextflow,linenums]
+----
 process {
     container = 'job-definition://your-job-definition-name'
 }
-```
+----
 
 == Custom image
 
@@ -150,21 +154,23 @@ IMPORTANT: When creating your custom AMI for AWS Batch, make sure to use the _Am
 
 The following snippet shows how to install AWS CLI with Miniconda:
 
-```
+[cmd,linenums]
+----
 sudo yum install -y bzip2 wget
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh -b -f -p $HOME/miniconda
 $HOME/miniconda/bin/conda install -c conda-forge -y awscli
 rm Miniconda3-latest-Linux-x86_64.sh
-```
+----
 
 NOTE: The `aws` tool will be placed in a directory named `bin` in the main installation folder. Modifying this directory structure, after the installation, will cause the tool to not work properly.
 
 Finally, specify the `aws` full path in the Nextflow config file as shown below:
 
-```
+[source,config]
+----
 aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
-```
+----
 
 
 == Launch template
@@ -175,7 +181,8 @@ installs the AWS CLI tool during the instance boot using custom user data.
 
 In the EC2 dashboard, create a Launch template specifying the following in the user data field:
 
-```
+[source,config,linenums]
+----
 MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="//"
 
@@ -198,7 +205,7 @@ rm Miniconda3-latest-Linux-x86_64.sh
 chown -R ec2-user:ec2-user $USER/miniconda
 
 --//--
-```
+----
 
 Then in the Batch dashboard create a new compute environment and specify the newly created
 launch template in the corresponding field.
@@ -216,7 +223,8 @@ To take advantage of this mechanism with AWS Batch, we also need to make sure th
 
 The aforementioned pattern can be implemented using the following launch template:
 
-```
+[source,config,linenums]
+----
 MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="//"
 
@@ -261,7 +269,7 @@ EOF
 cp ~/boot.log ~ec2-user/boot.log
 
 --//--
-```
+----
 
 Once created, the template can be specified when creating the AWS Batch
 compute environment.
@@ -285,7 +293,8 @@ The Nextflow extended executor for Batch takes care of the mounting of the share
 
 The following launch template can be used to mount the Lustre shared file system:
 
-```
+[source,config,linenums]
+----
 MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="//"
 
@@ -338,7 +347,7 @@ EOF
 cp ~/boot.log ~ec2-user/boot.log
 
 --//--
-```
+----
 
 In the above snippet, replace the variables `FSXNAME` and `SCRATCH` with the appropriate values
 corresponding to your environment.
@@ -349,14 +358,15 @@ NOTE: Nextflow has to be launched from an instance having access to the same FSx
 
 Use the following snippet to install the Lustre client:
 
-```
+[cmd,linenums]
+----
 SCRATCH=/scratch
 FSXNAME=fs-0269031ec160509c9.fsx.eu-west-1.amazonaws.com
 sudo yum  install -y lustre-client
 sudo mkdir -p $SCRATCH
 sudo mount -t lustre -o noatime,flock $FSXNAME@tcp:/fsx $SCRATCH
 sudo chown ec2-user:ec2-user $SCRATCH
-```
+----
 
 NOTE: Make also sure the storage and the computing nodes use the same VPC and security groups.
 For further details check https://docs.aws.amazon.com/fsx/latest/LustreGuide/limit-access-security-groups.html[here].
@@ -365,25 +375,28 @@ For further details check https://docs.aws.amazon.com/fsx/latest/LustreGuide/lim
 
 Define the following env variable:
 
-```
+[cmd]
+----
 export NXF_GRAB=io.seqera:nf-xpack:0.2.0
-```
+----
 
 Define basic Nextflow configuration parameters:
 
-```
+[source,config,linenums]
+----
 process.container = 'nextflow/rnaseq-nf:latest'
 process.executor = 'awsbatch'
 process.queue = 'nf-queue-with-fsx'
 aws.region = 'eu-west-1'
 workDir = '/scratch/work'
-```
+----
 
 Then run Nextflow as usual:
 
-```
+[cmd]
+----
 nextflow run rnaseq-nf
-```
+----
 
 NOTE: This requires an extra endpoint configuration to access the Nf-xpack distribution.
 
@@ -406,7 +419,8 @@ avoid too many parallel jobs in the compute instance).
 
 Also, the following parameters can be used to help to mitigate this issue:
 
-```
+[source,config,linenums]
+----
 aws {
     batch {
         maxTransferAttempts = 20
@@ -423,7 +437,7 @@ aws {
         maxErrorRetry = 20
     }
 }
-```
+----
 
 Advanced configuration settings are described at https://www.nextflow.io/docs/latest/config.html#scope-aws[this link].
 

--- a/asciidocs/cache_and_resume.adoc
+++ b/asciidocs/cache_and_resume.adoc
@@ -9,7 +9,8 @@ composing the task input values, files and command string.
 
 The pipeline work directory is organized as shown below:
 
-```
+[cmd,linenums]
+----
 work/
 ├── 12
 │   └── 1adacb582d2198cd32db0e6f808bce
@@ -44,7 +45,7 @@ work/
 │       ├── ggal_gut_1.fq -> /data/../ggal_gut_1.fq
 │       ├── ggal_gut_2.fq -> /data/../ggal_gut_2.fq
 │       └── index -> /data/../asciidocs/day2/work/12/1adacb582d2198cd32db0e6f808bce/index
-```
+----
 
 TIP: You can create these plots using the `tree` function if you have it installed. On unix, simply `sudo apt install  -y tree` or with Homebrew: `brew install tree`
 
@@ -53,9 +54,10 @@ TIP: You can create these plots using the `tree` function if you have it install
 The `-resume` command-line option allows the continuation of a pipeline
 execution from the last step that was completed successfully:
 
-```
+[cmd]
+----
 nextflow run <script> -resume
-```
+----
 
 In practical terms, the pipeline is executed from the beginning. However, before launching the execution of a `process`, Nextflow
 uses the task unique ID to check if the work directory already exists and that it contains a valid command exit state with the
@@ -79,9 +81,10 @@ IMPORTANT: Make sure to delete your work directory occasionally, else your machi
 A different location for the execution work directory can be specified
 using the command line option `-w`. For example:
 
-```
+[cmd]
+----
 nextflow run <script> -w /some/scratch/dir
-```
+----
 
 WARNING: If you delete or move the pipeline work directory, it will prevent the use of the resume feature in subsequent runs.
 
@@ -116,9 +119,10 @@ TIMESTAMP            DURATION  RUN NAME          STATUS  REVISION ID  SESSION ID
 
 You can use either the *session ID* or the *run name* to recover a specific execution. For example:
 
-```
+[cmd]
+----
 nextflow run rnaseq-nf -resume mighty_boyd
-```
+----
 
 == Execution provenance
 
@@ -142,7 +146,8 @@ $ nextflow log tiny_fermat
 The `-f` (fields) option can be used to specify which metadata
 should be printed by the `log` command. For example:
 
-```
+[cmd,linenums]
+----
 $ nextflow log tiny_fermat -f 'process,exit,hash,duration'
 
 index    0   7b/3753ff  2.0s
@@ -151,23 +156,25 @@ fastqc   0   f7/659c65  9.1s
 quant    0   82/ba67e3  2.7s
 quant    0   e5/2816b9  3.2s
 multiqc  0   3b/3485d0  6.3s
-```
+----
 
 The complete list of available fields can be retrieved with the command:
 
-```
+[cmd]
+----
 nextflow log -l
-```
+----
 
 The `-F` option allows the specification of filtering criteria to
 print only a subset of tasks. For example:
 
-```
+[cmd,linenums]
+----
 $ nextflow log tiny_fermat -F 'process =~ /fastqc/'
 
 /data/.../work/c1/56a36d8f498c99ac6cba31e85b3e0c
 /data/.../work/f7/659c65ef60582d9713252bcfbcc310
-```
+----
 
 This can be useful to locate specific task work directories.
 
@@ -194,9 +201,10 @@ Script:
 Save the above snippet in a file named `template.html`. Then
 run this command (using the correct id for your run, e.g. not tiny_fermat):
 
-```
+[cmd]
+----
 nextflow log tiny_fermat -t template.html > prov.html
-```
+----
 
 Finally, open the `prov.html` file with a browser.
 

--- a/asciidocs/cache_and_resume.adoc
+++ b/asciidocs/cache_and_resume.adoc
@@ -9,7 +9,7 @@ composing the task input values, files and command string.
 
 The pipeline work directory is organized as shown below:
 
-[cmd,linenums]
+[cmd]
 ----
 work/
 ├── 12
@@ -106,7 +106,7 @@ directory concurrently should be avoided.
 
 The `nextflow log` command lists the executions run in the current folder:
 
-[source,bash,linenums]
+[cmd]
 ----
 $ nextflow log
 
@@ -131,7 +131,7 @@ The `log` command, when provided with a *run name* or *session ID*, can return m
 By default, it will list the work directories used to compute each task.
 For example:
 
-[source]
+[cmd]
 ----
 $ nextflow log tiny_fermat
 
@@ -146,7 +146,7 @@ $ nextflow log tiny_fermat
 The `-f` (fields) option can be used to specify which metadata
 should be printed by the `log` command. For example:
 
-[cmd,linenums]
+[cmd]
 ----
 $ nextflow log tiny_fermat -f 'process,exit,hash,duration'
 

--- a/asciidocs/channels.adoc
+++ b/asciidocs/channels.adoc
@@ -63,11 +63,12 @@ ch.view()
 
 It prints:
 
-```
+[cmd,linenums]
+----
 Hello
 Hello
 Hello
-```
+----
 
 A `value` channel is created using the https://www.nextflow.io/docs/latest/channel.html#value[value] factory method or by operators returning a single value, such as https://www.nextflow.io/docs/latest/operator.html#first[first], https://www.nextflow.io/docs/latest/operator.html#last[last], https://www.nextflow.io/docs/latest/operator.html#operator-collect[collect], https://www.nextflow.io/docs/latest/operator.html#operator-count[count], https://www.nextflow.io/docs/latest/operator.html#operator-min[min], https://www.nextflow.io/docs/latest/operator.html#operator-max[max], https://www.nextflow.io/docs/latest/operator.html#operator-reduce[reduce], and https://www.nextflow.io/docs/latest/operator.html#operator-sum[sum].
 
@@ -103,6 +104,7 @@ ch.view{ "value: $it" }
 
 The first line in this example creates a variable `ch` which holds a channel object. This channel emits the values specified as a parameter in the `of` method. Thus the second line will print the following:
 
+[cmd,linenums]
 ----
 value: 1
 value: 3
@@ -140,7 +142,7 @@ Channel
 The `fromPath` factory method creates a queue channel emitting one or more files
 matching the specified glob pattern.
 
-[source,nextflow,linenums]
+[source,nextflow]
 ----
 Channel.fromPath( './data/meta/*.csv' )
 ----
@@ -188,7 +190,7 @@ Use the `Channel.fromPath` method to create a channel emitting all files with th
 .Click here for the answer:
 [%collapsible]
 ====
-[source,nextflow]
+[source,nextflow,linenums]
 ----
 Channel.fromPath( './data/ggal/**.fq' , hidden:true)
   .view()
@@ -209,11 +211,12 @@ Channel
 
 It will produce an output similar to the following:
 
-```
+[cmd,linenums]
+----
 [liver, [/user/nf-training/data/ggal/liver_1.fq, /user/nf-training/data/ggal/liver_2.fq]]
 [gut, [/user/nf-training/data/ggal/gut_1.fq, /user/nf-training/data/ggal/gut_2.fq]]
 [lung, [/user/nf-training/data/ggal/lung_1.fq, /user/nf-training/data/ggal/lung_2.fq]]
-```
+----
 
 IMPORTANT: The glob pattern must contain at least a star wildcard character.
 
@@ -256,7 +259,7 @@ directory and print them. Then use the `flat:true` option and compare the output
 ====
 Use the following, with or without 'flat:true':
 
-[source,nextflow]
+[source,nextflow,linenums]
 ----
 Channel.fromFilePairs( './data/ggal/*_{1,2}.fq', flat:true)
   .view()
@@ -303,7 +306,7 @@ IMPORTANT: Replace `<Your API key here>` with your API key.
 
 This should print:
 
-[source,text,linenums]
+[cmd,linenums]
 ----
 [SRR3383346, [/vol1/fastq/SRR338/006/SRR3383346/SRR3383346_1.fastq.gz, /vol1/fastq/SRR338/006/SRR3383346/SRR3383346_2.fastq.gz]]
 [SRR3383347, [/vol1/fastq/SRR338/007/SRR3383347/SRR3383347_1.fastq.gz, /vol1/fastq/SRR338/007/SRR3383347/SRR3383347_2.fastq.gz]]
@@ -322,7 +325,7 @@ Channel
   .view()
 ----
 
-[source,text,linenums]
+[cmd,linenums]
 ----
 [ERR908507, [/vol1/fastq/ERR908/ERR908507/ERR908507_1.fastq.gz, /vol1/fastq/ERR908/ERR908507/ERR908507_2.fastq.gz]]
 [ERR908506, [/vol1/fastq/ERR908/ERR908506/ERR908506_1.fastq.gz, /vol1/fastq/ERR908/ERR908506/ERR908506_2.fastq.gz]]
@@ -365,6 +368,7 @@ If you want to run the pipeline above and do not have fastqc installed in your m
 
 The `splitText` operator allows you to split multi-line strings or text file items, emitted by a source channel into chunks containing n lines, which will be emitted by the resulting channel. See:
 
+[source,nextflow,linenums]
 ----
 Channel
   .fromPath('data/meta/random.txt') // <1>
@@ -379,6 +383,7 @@ Channel
 
 You can define the number of lines in each chunk by using the parameter `by`, as shown in the following example:
 
+[source,nextflow,linenums]
 ----
 Channel
   .fromPath('data/meta/random.txt')
@@ -393,6 +398,7 @@ TIP: The `subscribe` operator permits execution of user defined functions each t
 
 An optional closure can be specified in order to transform the text chunks produced by the operator. The following example shows how to split text files into chunks of 10 lines and transform them into capital letters:
 
+[source,nextflow,linenums]
 ----
 Channel
   .fromPath('data/meta/random.txt')
@@ -402,6 +408,7 @@ Channel
 
 You can also make counts for each line:
 
+[source,nextflow,linenums]
 ----
 count=0
 
@@ -413,6 +420,7 @@ Channel
 
 Finally, you can also use the operator on plain files (outside of the channel context):
 
+[source,nextflow,linenums]
 ----
   def f = file('data/meta/random.txt')
   def lines = f.splitText()
@@ -430,6 +438,7 @@ It then splits them into records or groups them as a list of records with a spec
 
 In the simplest case, just apply the `splitCsv` operator to a channel emitting a CSV formatted text files or text entries. For example, to view only the first and fourth columns:
 
+[source,nextflow,linenums]
 ----
 Channel
   .fromPath("data/meta/patients_1.csv")
@@ -440,6 +449,7 @@ Channel
 
 When the CSV begins with a header line defining the column names, you can specify the parameter `header: true` which allows you to reference each value by its column name, as shown in the following example:
 
+[source,nextflow,linenums]
 ----
 Channel
   .fromPath("data/meta/patients_1.csv")
@@ -450,6 +460,7 @@ Channel
 
 Alternatively, you can provide custom header names by specifying a list of strings in the header parameter as shown below:
 
+[source,nextflow,linenums]
 ----
 Channel
   .fromPath("data/meta/patients_1.csv")
@@ -460,6 +471,7 @@ Channel
 
 You can also process multiple csv files at the same time:
 
+[source,nextflow,linenums]
 ----
 Channel
   .fromPath("data/meta/patients_*.csv") // <-- just use a pattern
@@ -471,6 +483,7 @@ TIP: Notice that you can change the output format simply by adding a different d
 
 Finally, you can also operate on csv files outside the channel context:
 
+[source,nextflow,linenums]
 ----
 def f = file('data/meta/patients_1.csv')
   def lines = f.splitCsv()
@@ -489,7 +502,7 @@ Try inputting fastq reads into the RNA-Seq workflow from earlier using `.splitCS
 ====
 Add a csv text file containing the following, as an example input with the name "fastq.csv":
 
-[source,nextflow,linenums]
+[cmd]
 ----
 gut,/workspace/nf-training-public/nf-training/data/ggal/gut_1.fq,/workspace/nf-training-public/nf-training/data/ggal/gut_2.fq
 ----
@@ -583,6 +596,7 @@ Now the workflow should run from a CSV file.
 
 Parsing tsv files works in a similar way, simply add the `sep:'\t'` option in the `splitCsv` context:
 
+[source,nextflow,linenums]
 ----
 Channel
   .fromPath("data/meta/regions.tsv", checkIfExists:true)
@@ -600,12 +614,15 @@ Try using the tab separation technique on the file "data/meta/regions.tsv", but 
 .Answer:
 [%collapsible]
 ====
+[source,nextflow,linenums]
+----
 Channel
   .fromPath("data/meta/regions.tsv", checkIfExists:true)
   // use `sep` option to parse TAB separated files
   .splitCsv(sep:'\t', header:true )
   // row is a list object
   .view { row -> "${row.patient_id}" }
+----
 ====
 
 == More complex file formats
@@ -614,6 +631,7 @@ Channel
 
 We can also easily parse the JSON file format using the following groovy schema:
 
+[source,nextflow,linenums]
 ----
 import groovy.json.JsonSlurper
 
@@ -632,6 +650,7 @@ IMPORTANT: When using an older JSON version, you may need to replace `parse(f)` 
 
 This can also be used as a way to parse YAML files:
 
+[source,nextflow,linenums]
 ----
 import org.yaml.snakeyaml.Yaml
 
@@ -650,6 +669,7 @@ The best way to store parser scripts is to keep them in a Nextflow module file.
 
 See the following Nextflow script:
 
+[source,nextflow,linenums]
 ----
 include{ parseJsonFile } from './modules/parsers.nf'
 

--- a/asciidocs/config.adoc
+++ b/asciidocs/config.adoc
@@ -17,9 +17,10 @@ The default config file search mechanism can be extended by providing an extra c
 
 A Nextflow configuration file is a simple text file containing a set of properties defined using the syntax:
 
-```
+[source,config]
+----
 name = value
-```
+----
 
 TIP: Please note that string values need to be wrapped in quotation characters while numbers and boolean values (`true`, `false`) do not. Also, note that values are typed, meaning for example that, `1` is different from `'1'`, since the first is interpreted as the number one, while the latter is interpreted as a string value.
 
@@ -41,7 +42,7 @@ such as `$PATH`, `$HOME`, `$PWD`, etc.
 
 Configuration files use the same conventions for comments used in the Nextflow script:
 
-[source,nextflow,linenums]
+[source,config,linenums]
 ----
 // comment a single line
 
@@ -96,9 +97,10 @@ println "$params.foo $params.bar"
 
 Save the first snippet as `nextflow.config` and the second one as `params.nf`. Then run:
 
-```cmd
+[cmd]
+----
 nextflow run params.nf
-```
+----
 
 .For the result, click here:
 [%collapsible]
@@ -111,9 +113,10 @@ Bonjour le monde!
 
 Execute is again specifying the `foo` parameter on the command line:
 
-```cmd
+[cmd]
+----
 nextflow run params.nf --foo Hola
-```
+----
 
 .For the result, click here:
 [%collapsible]
@@ -154,14 +157,15 @@ process foo {
 
 Finally, execute the following command:
 
-```
+[cmd]
+----
 nextflow run foo.nf -c my-env.config
-```
+----
 
 .Your result should look something like the following, click here:
 [%collapsible]
 ====
-[source,nextflow]
+[cmd,linenums]
 ----
 BETA=/home/some/path
 ALPHA=some value
@@ -251,31 +255,34 @@ process foo {
 This is especially important when you want to define a config setting
 using a dynamic expression using a closure. For example:
 
-```
+[source,config,linenums]
+----
 process foo {
     memory = { 4.GB * task.cpus }
 }
-```
+----
 
 Directives that require more than one value, e.g. https://www.nextflow.io/docs/latest/process.html#pod[pod], in the
 configuration file need to be expressed as a map object.
 
-```
+[source,config,linenums]
+----
 process {
     pod = [env: 'FOO', value: '123']
 }
-```
+----
 
 Finally, directives that are to be repeated in the process
 definition, in the configuration files need to be defined
 as a list object. For example:
 
-```
+[source,config,linenums]
+----
 process {
     pod = [ [env: 'FOO', value: '123'],
             [env: 'BAR', value: '456'] ]
 }
-```
+----
 
 === Config Docker execution
 
@@ -342,9 +349,10 @@ or the `process.container` setting in the config file.
 
 Try to run the script as shown below, changing the `nextflow.config` file to the one above using `singularity`:
 
-```bash
+[cmd]
+----
 nextflow run script7.nf
-```
+----
 
 TIP: Nextflow will pull the container image automatically, it will require a few seconds
 depending on the network connection speed.

--- a/asciidocs/config.adoc
+++ b/asciidocs/config.adoc
@@ -105,7 +105,7 @@ nextflow run params.nf
 .For the result, click here:
 [%collapsible]
 ====
-[source,nextflow]
+[cmd]
 ----
 Bonjour le monde!
 ----
@@ -121,7 +121,7 @@ nextflow run params.nf --foo Hola
 .For the result, click here:
 [%collapsible]
 ====
-[source,nextflow]
+[cmd]
 ----
 Hola le monde!
 ----
@@ -239,6 +239,8 @@ workflow script.
 .For an example, click here:
 [%collapsible]
 ====
+[source,nextflow,linenums]
+----
 process foo {
   cpus 4
   memory 2.GB
@@ -250,12 +252,13 @@ process foo {
     your_command --cpus $task.cpus --mem $task.memory
   """
 }
+----
 ====
 
 This is especially important when you want to define a config setting
 using a dynamic expression using a closure. For example:
 
-[source,config,linenums]
+[source,nextflow,linenums]
 ----
 process foo {
     memory = { 4.GB * task.cpus }
@@ -362,7 +365,7 @@ depending on the network connection speed.
 The use of a Conda environment can also be provided in the configuration file
 by adding the following setting in the `nextflow.config` file:
 
-[source,config,linenums,options="nowrap"]
+[source,config,options="nowrap"]
 ----
 process.conda = "/home/ubuntu/miniconda2/envs/nf-tutorial"
 ----

--- a/asciidocs/containers.adoc
+++ b/asciidocs/containers.adoc
@@ -537,10 +537,10 @@ docker push <myrepo>/my-image
 ----
 --
 
-4. Add the image file name to the nextflow.config file.
+4. Add the image file name to the `nextflow.config` file.
 +
 --
-e.g. remove the following from the nextflow.config:
+e.g. remove the following from the `nextflow.config`:
 
 [source,config]
 ----
@@ -611,8 +611,8 @@ HINT: Temporarily comment out the line `process.container = 'nextflow/rnaseq-nf'
 ----
 nextflow run script5.nf
 ----
-#with the following container directives for each process:
-[source,nextflow]
+with the following container directives for each process:
+[source,nextflow,linenums]
 ----
 process FASTQC {
     container = 'biocontainers/fastqc:v0.11.5'
@@ -622,7 +622,7 @@ process FASTQC {
 
 and
 
-[source,nextflow]
+[source,nextflow,linenums]
 ----
 process QUANTIFICATION {
     tag "Salmon on $sample_id"
@@ -631,7 +631,7 @@ process QUANTIFICATION {
 ...
 ----
 
-# Check the .command.run file in the work directory and ensure that the run line contains the correct Biocontainers.
+Check the `.command.run` file in the work directory and ensure that the run line contains the correct Biocontainers.
 ====
 
 [discrete]

--- a/asciidocs/containers.adoc
+++ b/asciidocs/containers.adoc
@@ -25,38 +25,43 @@ https://hub.docker.com[Docker Hub], or hosted by other parties like https://quay
 
 A container can be run using the following command:
 
-```bash
+[cmd]
+----
 docker run <container-name>
-```
+----
 
 Try for example the following publically available container (if you have docker installed):
 
-```bash
+[cmd]
+----
 docker run hello-world
-```
+----
 
 === Pull a container
 
 The pull command allows you to download a Docker image without running it. For example:
 
-```bash
+[cmd]
+----
 docker pull debian:stretch-slim
-```
+----
 
 The above command downloads a Debian Linux image. You can check it exists by using:
 
-```bash
+[cmd]
+----
 docker images
-```
+----
 
 === Run a container in interactive mode
 
 Launching a BASH shell in the container allows you to operate in an interactive mode
 in the containerized operating system. For example:
 
-```bash
+[cmd]
+----
 docker run -it debian:stretch-slim bash
-```
+----
 
 Once launched, you will notice that it is running as root (!).
 Use the usual commands to navigate the file system.
@@ -96,9 +101,10 @@ ENV PATH=$PATH:/usr/games/
 
 Build the Dockerfile image by using the following command:
 
-```bash
+[cmd]
+----
 docker build -t my-image .
-```
+----
 
 Where "my-image" is the user-specified name tag for the Dockerfile, present in the current directory.
 
@@ -107,15 +113,17 @@ IMPORTANT: Don't miss the dot in the above command.
 When it completes, verify that the image
 has been created by listing all available images:
 
-```bash
+[cmd]
+----
 docker images
-```
+----
 
 You can try your new container by running this command:
 
-```bash
+[cmd]
+----
 docker run my-image cowsay Hello Docker!
-```
+----
 
 === Add a software package to the image
 
@@ -130,9 +138,10 @@ RUN curl -sSL https://github.com/COMBINE-lab/salmon/releases/download/v1.5.2/sal
 
 Save the file and build the image again with the same command as before:
 
-```bash
+[cmd]
+----
 docker build -t my-image .
-```
+----
 
 You will notice that it creates a new Docker image with the same name *but* with a different image ID.
 
@@ -140,15 +149,17 @@ You will notice that it creates a new Docker image with the same name *but* with
 
 Check that Salmon is running correctly in the container as shown below:
 
-```bash
+[cmd]
+----
 docker run my-image salmon --version
-```
+----
 
 You can even launch a container in an interactive mode by using the following command:
 
-```bash
+[cmd]
+----
 docker run -it my-image bash
-```
+----
 
 Use the `exit` command to terminate the interactive session.
 
@@ -158,10 +169,11 @@ Create a genome index file by running Salmon in the container.
 
 Try to run Salmon in the container with the following command:
 
-```bash
+[cmd]
+----
 docker run my-image \
   salmon index -t $PWD/data/ggal/transcriptome.fa -i transcript-index
-```
+----
 
 The above command fails because Salmon cannot access the input file.
 
@@ -170,34 +182,38 @@ it cannot access the hosting file system by default.
 
 You will need to use the `--volume` command-line option to mount the input file(s) e.g.
 
-```bash
+[cmd]
+----
 docker run --volume $PWD/data/ggal/transcriptome.fa:/transcriptome.fa my-image \
   salmon index -t /transcriptome.fa -i transcript-index
-```
+----
 
 IMPORTANT: The generated `transcript-index` directory is still not accessible in the host file system.
 
 TIP: An easier way is to mount a parent directory to an identical one in the container,
 this allows you to use the same path when running it in the container e.g.
 
-```bash
+[cmd]
+----
 docker run --volume $PWD:$PWD --workdir $PWD my-image \
   salmon index -t $PWD/data/ggal/transcriptome.fa -i transcript-index
-```
+----
 
 Or set a folder you want to mount as an environmental variable, called `DATA`:
 
-```bash
+[cmd]
+----
 DATA=/workspace/nf-training-public/nf-training/data
 docker run --volume $DATA:$DATA --workdir $PWD my-image \
   salmon index -t $PWD/data/ggal/transcriptome.fa -i transcript-index
-```
+----
 
 Now check the content of the `transcript-index` folder by entering the command:
 
-```bash
+[cmd]
+----
 ls -la transcript-index
-```
+----
 
 IMPORTANT: Note that the permissions for files created by the Docker execution is `root`.
 
@@ -208,50 +224,57 @@ Publish your container in the Docker Hub to share it with other people.
 Create an account on the https://hub.docker.com website. Then from your shell terminal run
 the following command, entering the user name and password you specified when registering in the Hub:
 
-```bash
+[cmd]
+----
 docker login
-```
+----
 
 Tag the image with your Docker user name account:
 
-```bash
+[cmd]
+----
 docker tag my-image <user-name>/my-image
-```
+----
 
 Finally push it to the Docker Hub:
 
-```bash
+[cmd]
+----
 docker push <user-name>/my-image
-```
+----
 
 After that anyone will be able to download it by using the command:
 
-```bash
+[cmd]
+----
 docker pull <user-name>/my-image
-```
+----
 
 Note how after a pull and push operation, Docker prints the container digest number e.g.
 
-```bash
+[cmd]
+----
 Digest: sha256:aeacbd7ea1154f263cda972a96920fb228b2033544c2641476350b9317dab266
 Status: Downloaded newer image for nextflow/rnaseq-nf:latest
-```
+----
 
 This is a unique and immutable identifier that can be used to reference a container image
 in a univocally manner. For example:
 
-```bash
+[cmd]
+----
 docker pull nextflow/rnaseq-nf@sha256:aeacbd7ea1154f263cda972a96920fb228b2033544c2641476350b9317dab266
-```
+----
 
 === Run a Nextflow script using a Docker container
 
 The simplest way to run a Nextflow script with a Docker image is using the
 `-with-docker` command-line option:
 
-```
+[cmd]
+----
 nextflow run script2.nf -with-docker my-image
-```
+----
 
 As seen in the last section, you can also configure the Nextflow config file (`nextflow.config`) to select which container to use instead of having to specify it as a command-line argument every time.
 
@@ -294,9 +317,10 @@ curl -sSL https://github.com/COMBINE-lab/salmon/releases/download/v1.0.0/salmon-
 
 Once you have saved the `Singularity` file. You can create the image with these commands:
 
-```bash
+[cmd]
+----
 sudo singularity build my-image.sif Singularity
-```
+----
 
 Note: the `build` command requires `sudo` permissions. A common workaround
 consists of building the image on a local workstation and then deploying it in the
@@ -306,23 +330,26 @@ cluster by copying the image file.
 
 Once done, you can run your container with the following command
 
-```bash
+[cmd]
+----
 singularity exec my-image.sif cowsay 'Hello Singularity'
-```
+----
 
 By using the `shell` command you can enter in the container in interactive mode.
 For example:
 
-```bash
+[cmd]
+----
 singularity shell my-image.sif
-```
+----
 
 Once in the container instance run the following commands:
 
-```bash
+[cmd]
+----
 touch hello.txt
 ls -la
-```
+----
 
 TIP: Note how the files on the host environment are shown. Singularity automatically
 mounts the host `$HOME` directory and uses the current work directory.
@@ -331,9 +358,10 @@ mounts the host `$HOME` directory and uses the current work directory.
 
 An easier way to create a Singularity container without requiring sudo permission and boosting the containers interoperability is to import a Docker container image by pulling it directly from a Docker registry. For example:
 
-```bash
+[cmd]
+----
 singularity pull docker://debian:stretch-slim
-```
+----
 
 The above command automatically downloads the Debian Docker image and converts it to
 a Singularity image in the current directory with the name `debian-jessie.simg`.
@@ -344,9 +372,10 @@ Nextflow allows the transparent usage of Singularity containers as easy as with 
 
 Simply enable the use of the Singularity engine in place of Docker in the Nextflow configuration file by using the `-with-singularity` command-line option:
 
-```bash
+[cmd]
+----
 nextflow run script7.nf -with-singularity nextflow/rnaseq-nf
-```
+----
 
 As before, the Singularity container can also be provided in the Nextflow config file. We'll see how to do this later.
 
@@ -368,14 +397,16 @@ In this Gitpod environment, conda is already installed.
 
 A Conda environment is defined using a YAML file, which lists the required software packages. The first thing you need to do is to initiate conda for shell interaction, and then open a new terminal by running bash.
 
-```
+[cmd,linenums]
+----
 conda init
 bash
-```
+----
 
 Then write your YAML file. For example:
 
-```yaml
+[source,yaml,linenums]
+----
 name: nf-tutorial
 channels:
   - conda-forge
@@ -386,40 +417,45 @@ dependencies:
   - bioconda::fastqc=0.11.9
   - bioconda::multiqc=1.12
   - conda-forge::tbb=2020.2
-```
+----
 
 Given the recipe file, the environment is created using the command shown below:
 
-```bash
+[cmd]
+----
 conda env create --file env.yml
-```
+----
 
 You can check the environment was created successfully with the command shown below:
 
-```bash
+[cmd]
+----
 conda env list
-```
+----
 
 This should look something like this:
-```bash
+[cmd,linenums]
+----
 # conda environments:
 #
 base                  *  /opt/conda
 nf-tutorial              /opt/conda/envs/nf-tutorial
-```
+----
 
 To enable the environment you can use the `activate` command:
 
-```bash
+[cmd]
+----
 conda activate nf-tutorial
-```
+----
 
 Nextflow is able to manage the activation of a Conda environment when its directory
 is specified using the `-with-conda` option (using the same path shown in the `list` function. For example:
 
-```bash
+[cmd]
+----
 nextflow run script7.nf -with-conda /opt/conda/envs/nf-tutorial
-```
+----
 
 TIP: When creating a Conda environment with a YAML recipe file, Nextflow automatically downloads the required dependencies, builds the environment and activates it.
 
@@ -438,7 +474,8 @@ This saves having to build a conda environment each time you want to use it (as 
 
 To do this, you simply require a `Dockerfile` and you use micromamba to install the packages. However, a good practice is to have a YAML recipe file like in the previous section, so we'll do it here too.
 
-```yaml
+[source,yaml,linenums]
+----
 name: nf-tutorial
 channels:
   - conda-forge
@@ -449,11 +486,12 @@ dependencies:
   - bioconda::fastqc=0.11.9
   - bioconda::multiqc=1.12
   - conda-forge::tbb=2020.2
-```
+----
 
 Then, we can write our Dockerfile with micromamba installing the packages from this recipe file.
 
-```Dockerfile
+[source,docker,linenums,options="nowrap"]
+----
 FROM mambaorg/micromamba:0.25.1
 
 MAINTAINER  Your name <your_email>
@@ -466,7 +504,7 @@ RUN micromamba install -y -n nf-tutorial -f /tmp/env.yml && \
     micromamba clean --all --yes
 
 ENV PATH /opt/conda/envs/nf-tutorial/bin:$PATH
-```
+----
 
 The above `Dockerfile` takes the parent image 'mambaorg/micromamba', then installs a `conda` environment using `micromamba`, and installs `salmon`, `fastqc` and `multiqc`.
 
@@ -491,11 +529,12 @@ Something similar to the following, with <myrepo> replaced with your own Docker 
 
 TIP: "my-image" could be replaced with any name you choose. As good practice, choose something memorable and ensure the name matches the name you used in the previous command.
 
-```
+[cmd]
+----
 docker login
 docker tag my-image <myrepo>/my-image
 docker push <myrepo>/my-image
-```
+----
 --
 
 4. Add the image file name to the nextflow.config file.
@@ -503,24 +542,27 @@ docker push <myrepo>/my-image
 --
 e.g. remove the following from the nextflow.config:
 
-```
+[source,config]
+----
 process.container = 'nextflow/rnaseq-nf'
-```
+----
 
 and replace with:
 
-```
+[source,config]
+----
 process.container = '<myrepo>/my-image'
-```
+----
 
 --
 
 5. Trying running Nextflow, e.g.:
 +
 --
-```
+[cmd]
+----
 nextflow run script7.nf -with-docker
-```
+----
 --
 
 Nextflow should now be able to find `salmon` to run the process.
@@ -532,9 +574,10 @@ Another useful resource linking together Bioconda and containers is the https://
 
 So far, we've seen how to install packages with conda and micromamba, both locally and within containers. With BioContainers, you don't need to create your own container image for the tools you want, and you don't need to use conda or micromamba to install the packages. It already provides you with a Docker image containing the programs you want installed. For example, you can get the container image of fastqc using BioContainers with:
 
-```
+[cmd]
+----
 docker pull biocontainers/fastqc:v0.11.5
-```
+----
 
 You can check the registry for the packages you want in https://biocontainers.pro/registry[BioContainers official website].
 
@@ -548,7 +591,7 @@ During the earlier RNA-Seq tutorial (script2.nf), we created an index with the s
 .For the result, click here:
 [%collapsible]
 ====
-[source,nextflow]
+[cmd]
 ----
 nextflow run script2.nf -with-docker quay.io/biocontainers/salmon:1.7.0--h84f40af_0
 ----
@@ -564,27 +607,29 @@ HINT: Temporarily comment out the line `process.container = 'nextflow/rnaseq-nf'
 .For the result, click here:
 [%collapsible]
 ====
-[source,nextflow]
-```
+[cmd]
+----
 nextflow run script5.nf
-```
+----
 #with the following container directives for each process:
-```
+[source,nextflow]
+----
 process FASTQC {
     container = 'biocontainers/fastqc:v0.11.5'
     tag "FASTQC on $sample_id"
 ...
-```
+----
 
 and
 
-```
+[source,nextflow]
+----
 process QUANTIFICATION {
     tag "Salmon on $sample_id"
     container = 'quay.io/biocontainers/salmon:1.7.0--h84f40af_0'
     publishDir params.outdir, mode:'copy'
 ...
-```
+----
 
 # Check the .command.run file in the work directory and ensure that the run line contains the correct Biocontainers.
 ====

--- a/asciidocs/debugging.adoc
+++ b/asciidocs/debugging.adoc
@@ -4,7 +4,7 @@
 
 When a process execution exits with a non-zero exit status, Nextflow stops the workflow execution and reports the failing task:
 
-[source,cmd,options="nowrap"]
+[cmd,options="nowrap"]
 ----
 ERROR ~ Error executing process > 'index'
 

--- a/asciidocs/debugging.adoc
+++ b/asciidocs/debugging.adoc
@@ -76,7 +76,7 @@ process foo {
 
 If you want to ignore any error you can set the same directive in the config file as a default setting:
 
-[source,config,linenums]
+[source,config]
 ----
 process.errorStrategy = 'ignore'
 ----

--- a/asciidocs/executors.adoc
+++ b/asciidocs/executors.adoc
@@ -227,15 +227,17 @@ This configuration defines three different profiles: `standard`, `cluster` and `
 
 To enable a specific profile use `-profile` option followed by the profile name:
 
-```cmd
+[cmd]
+----
 nextflow run <your script> -profile cluster
-```
+----
 
 TIP: Two or more configuration profiles can be specified by separating the profile names with a comma character:
 
-```cmd
+[cmd]
+----
 nextflow run <your script> -profile standard,cloud
-```
+----
 
 
 == Cloud deployment
@@ -267,9 +269,10 @@ aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws' // <6>
 TIP: The best practice is to keep this setting as a separate profile in your
 workflow config file. This allows the execution with a simple command.
 
-```
+[cmd]
+----
 nextflow run script7.nf
-```
+----
 
 The complete details about AWS Batch deployment are available at https://www.nextflow.io/docs/latest/awscloud.html#aws-batch[this link].
 
@@ -277,24 +280,26 @@ The complete details about AWS Batch deployment are available at https://www.nex
 
 Elastic Block Storage (EBS) volumes (or other supported storage) can be mounted in the job container using the following configuration snippet:
 
-```
+[source,config,linenums]
+----
 aws {
   batch {
       volumes = '/some/path'
   }
 }
-```
+----
 
 Multiple volumes can be specified using comma-separated paths. The usual Docker volume mount syntax can be used to define complex volumes for which the container path is different from the host path or to specify a read-only option:
 
-```
+[source,config,linenums]
+----
 aws {
   region = 'eu-west-1'
   batch {
       volumes = ['/tmp', '/host/path:/mnt/path:ro']
   }
 }
-```
+----
 
 IMPORTANT: This is a global configuration that has to be specified in a Nextflow config file and will be applied to *all* process executions.
 
@@ -311,11 +316,12 @@ However, you may still need to specify a custom Job Definition to provide fine-g
 To use your own job definition in a Nextflow workflow, use it in place of the container image name,
 prefixing it with the `job-definition://` string. For example:
 
-```
+[source,config,linenums]
+----
 process {
     container = 'job-definition://your-job-definition-name'
 }
-```
+----
 
 == Custom image
 
@@ -325,21 +331,23 @@ IMPORTANT: When creating your custom AMI for AWS Batch, make sure to use the _Am
 
 The following snippet shows how to install AWS CLI with Miniconda:
 
-```
+[cmd,linenums]
+----
 sudo yum install -y bzip2 wget
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh -b -f -p $HOME/miniconda
 $HOME/miniconda/bin/conda install -c conda-forge -y awscli
 rm Miniconda3-latest-Linux-x86_64.sh
-```
+----
 
 NOTE: The `aws` tool will be placed in a directory named `bin` in the main installation folder. The tools will not work properly if you modify this directory structure after the installation.
 
 Finally, specify the `aws` full path in the Nextflow config file as shown below:
 
-```
+[source,config]
+----
 aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
-```
+----
 
 == Launch template
 
@@ -349,7 +357,8 @@ installs the AWS CLI tool during the instance boot via custom user data.
 
 In the EC2 dashboard, create a Launch template specifying the user data field:
 
-```
+[source,bash,linenums]
+----
 MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="//"
 
@@ -372,7 +381,7 @@ rm Miniconda3-latest-Linux-x86_64.sh
 chown -R ec2-user:ec2-user $USER/miniconda
 
 --//--
-```
+----
 
 Then create a new compute environment in the Batch dashboard and specify the newly created
 launch template in the corresponding field.

--- a/asciidocs/executors.adoc
+++ b/asciidocs/executors.adoc
@@ -18,7 +18,7 @@ image:nf-executors.png[]
 To run your pipeline with a batch scheduler, modify the `nextflow.config` file specifying
 the target executor and the required computing resources if needed. For example:
 
-[source,config,linenums,options="nowrap"]
+[source,config,options="nowrap"]
 ----
 process.executor = 'slurm'
 ----
@@ -101,7 +101,7 @@ Run the RNA-Seq script (script7.nf) from earlier, but specify that the `quantifi
 .Click here for the answer:
 [%collapsible]
 ====
-[source,nextflow,linenums]
+[source,config,linenums]
 ----
 process {
     withName: quantification {

--- a/asciidocs/groovy.adoc
+++ b/asciidocs/groovy.adoc
@@ -215,10 +215,11 @@ println y
 
 it prints:
 
-```
+[cmd]
+----
 tic\tac\toe
 tic    ac    oe
-```
+----
 
 == Multi-line strings
 
@@ -392,9 +393,10 @@ println x
 
 It prints:
 
-```
+[cmd]
+----
 [ 1, 4, 9, 16 ]
-```
+----
 
 By default, closures take a single parameter called `it`, to give it a different name use the
 `\->` syntax. For example:
@@ -418,11 +420,12 @@ values.each(printMap)
 
 It prints:
 
-```
+[cmd]
+----
 Yue with value Wu
 Mark with value Williams
 Sudha with value Kumari
-```
+----
 
 A closure has two other important features.
 

--- a/asciidocs/groovy.adoc
+++ b/asciidocs/groovy.adoc
@@ -8,7 +8,7 @@ Here are some important Groovy syntax that are commonly used in Nextflow.
 
 To print something is as easy as using one of the `print` or `println` methods.
 
-[source,groovy,linenums]
+[source,groovy]
 ----
 println("Hello, World!")
 ----
@@ -17,7 +17,7 @@ The only difference between the two is that the `println` method implicitly appe
 
 TIP: parentheses for function invocations are optional. Therefore, the following syntax is also valid :
 
-[source,groovy,linenums]
+[source,groovy]
 ----
 println "Hello, World!"
 ----
@@ -60,7 +60,7 @@ println x
 
 Local variables are defined using the `def` keyword:
 
-[source,groovy,linenums]
+[source,groovy]
 ----
 def x = 'foo'
 ----
@@ -71,7 +71,7 @@ The `def` should be always used when defining variables local to a function or a
 
 A List object can be defined by placing the list items in square brackets:
 
-[source,groovy,linenums]
+[source,groovy]
 ----
 list = [10,20,30,40]
 ----
@@ -86,7 +86,7 @@ println list.get(0)
 
 In order to get the length of a list you can use the size method:
 
-[source,groovy,linenums]
+[source,groovy]
 ----
 println list.size()
 ----
@@ -94,7 +94,7 @@ println list.size()
 We use the `assert` keyword to test if a condition is true (similar to an `if` function).
 Here, Groovy will print nothing if it is correct, else it will raise an AssertionError message.
 
-[source,groovy,linenums]
+[source,groovy]
 ----
 assert list[0] == 10
 ----
@@ -138,7 +138,7 @@ assert [4,2,1,3].findAll{it%2 == 0} == [4,2]
 
 Maps are like lists that have an arbitrary key instead of an integer. Therefore, the syntax is very much aligned.
 
-[source,groovy,linenums]
+[source,groovy]
 ----
 map = [a:0, b:1, c:2]
 ----
@@ -303,14 +303,14 @@ See the http://groovy-lang.org/semantics.html#Groovy-Truth[Groovy-Truth] for fur
 TIP: In some cases it can be useful to replace the `if` statement with a ternary expression (aka
 conditional expression). For example:
 
-[source,groovy,linenums]
+[source,groovy]
 ----
 println list ? list : 'The list is empty'
 ----
 
 The previous statement can be further simplified using the http://groovy-lang.org/operators.html#_elvis_operator[Elvis operator], as shown below:
 
-[source,groovy,linenums]
+[source,groovy]
 ----
 println list ?: 'The list is empty'
 ----
@@ -367,7 +367,7 @@ Closures are the Swiss army knife of Nextflow/Groovy programming. In a nutshell,
 
 More formally, a closure allows the definition of functions as first-class objects.
 
-[source,groovy,linenums]
+[source,groovy]
 ----
 square = { it * it }
 ----
@@ -401,7 +401,7 @@ It prints:
 By default, closures take a single parameter called `it`, to give it a different name use the
 `\->` syntax. For example:
 
-[source,groovy,linenums]
+[source,groovy]
 ----
 square = { num -> num * num }
 ----

--- a/asciidocs/intro.adoc
+++ b/asciidocs/intro.adoc
@@ -145,14 +145,14 @@ WARNING: For the Gitpod tutorial, make sure you are in the folder called `nf-tra
 
 Execute the script by entering the following command in your terminal:
 
-[source,cmd]
+[cmd]
 ----
 nextflow run hello.nf
 ----
 
 The output will look similar to the text shown below:
 
-[source,cmd,linenums]
+[cmd,linenums]
 ----
 N E X T F L O W  ~  version 22.04.2
 Launching `hello.nf` [tiny_venter] DSL2 - revision: 6879fb9372
@@ -193,11 +193,11 @@ It's worth noting that the process `CONVERTTOUPPER` is executed in parallel, so 
 Thus, it is perfectly possible that your final result will be
 printed out in a different order:
 
-[source,cmd]
-....
+[cmd,linenums]
+----
 WORLD!
 HELLO
-....
+----
 
 == Modify and resume
 
@@ -231,14 +231,14 @@ process CONVERTTOUPPER {
 Then save the file with the same name, and execute it by adding the
 `-resume` option to the command line:
 
-[source,cmd]
+[cmd]
 ----
 nextflow run hello.nf -resume
 ----
 
 It will print output similar to this:
 
-[source,cmd]
+[cmd,linenums]
 ----
 N E X T F L O W  ~  version 22.04.2
 Launching `hello.nf` [nostalgic_franklin] DSL2 - revision: 0b20bd3365
@@ -268,7 +268,7 @@ double dash character, i.e., `--paramName`.
 
 Now, let's try to execute the previous example specifying a different input string parameter, as shown below:
 
-[source,cmd]
+[cmd]
 ----
 nextflow run hello.nf --greeting 'Bonjour le monde!'
 ----
@@ -276,7 +276,7 @@ nextflow run hello.nf --greeting 'Bonjour le monde!'
 The string specified on the command line will override the default value
 of the parameter. The output will look like this:
 
-[source,cmd]
+[cmd,linenums]
 ----
 N E X T F L O W  ~  version 22.04.2
 Launching `hello.nf` [adoring_heyrovsky] DSL2 - revision: 0b20bd3365

--- a/asciidocs/modules.adoc
+++ b/asciidocs/modules.adoc
@@ -93,7 +93,7 @@ We now have modularized processes which makes the code more reusable and cleaner
 
 If a Nextflow module script contains multiple `process` definitions they can also be imported using a single `include` statement as shown in the example below:
 
-[source,nextflow,linenums]
+[source,nextflow]
 ----
 include { SPLITLETTERS; CONVERTTOUPPER } from './modules.nf'
 ----
@@ -136,7 +136,7 @@ Save the previous snippet as `hello.2.nf`, and predict the output to screen.
 [%collapsible]
 ====
 The `hello.2.nf` output should look something like this:
-[source,nextflow,linenums]
+[cmd]
 ----
 N E X T F L O W  ~  version 22.04.3
 Launching `hello.2.nf` [goofy_goldstine] DSL2 - revision: 449cf82eaf
@@ -469,7 +469,7 @@ workflow {
 
 Running `main.nf` should print:
 
-[source,bash,linenums]
+[cmd]
 ----
 Hola mundo!
 ----
@@ -496,7 +496,7 @@ workflow {
 
 Executing the main script above should print:
 
-[source,bash,linenums]
+[cmd]
 ----
 Olá mundo!
 ----

--- a/asciidocs/operators.adoc
+++ b/asciidocs/operators.adoc
@@ -62,11 +62,12 @@ Channel
 
 It prints:
 
-```
+[cmd]
+----
 foo
 bar
 baz
-```
+----
 
 An optional _closure_ parameter can be specified to customize how items are printed. For example:
 
@@ -79,6 +80,7 @@ Channel
 
 It prints:
 
+[cmd]
 ----
 - foo
 - bar
@@ -138,14 +140,15 @@ c3 = Channel.of( 'z' )
 c1 .mix(c2,c3).view()
 ----
 
-```
+[cmd]
+----
 1
 2
 a
 3
 b
 z
-```
+----
 
 IMPORTANT: The items in the resulting channel have the same order as in the respective original channels.
 However, there is no guarantee that the element of the second channel are appended after the elements
@@ -168,14 +171,15 @@ Channel
 
 The above snippet prints:
 
-```
+[cmd]
+----
 1
 2
 3
 4
 5
 6
-```
+----
 
 === collect
 
@@ -191,9 +195,10 @@ Channel
 
 It prints a single value:
 
-```
+[cmd]
+----
 [1,2,3,4]
-```
+----
 
 TIP: The result of the `collect` operator is a *value* channel.
 
@@ -213,11 +218,12 @@ Channel
 
 It shows:
 
-```
+[cmd]
+----
 [1, [A, B, C]]
 [2, [C, A]]
 [3, [B, D]]
-```
+----
 
 This operator is useful to process a group together with all the elements that share a common property or grouping key.
 
@@ -247,17 +253,18 @@ The `join` operator creates a channel that joins together the items emitted by t
 [source,nextflow,linenums]
 ----
 left = Channel.of(['X', 1], ['Y', 2], ['Z', 3], ['P', 7])
-right= Channel.of(['Z', 6], ['Y', 5], ['X', 4])
+right = Channel.of(['Z', 6], ['Y', 5], ['X', 4])
 left.join(right).view()
 ----
 
 The resulting channel emits:
 
-```
+[cmd]
+----
 [Z, 3, 6]
 [Y, 2, 5]
 [X, 1, 4]
-```
+----
 
 TIP: Notice 'P' is missing in the final result.
 

--- a/asciidocs/processes.adoc
+++ b/asciidocs/processes.adoc
@@ -239,10 +239,11 @@ The `input` block defines which channels the `process` is expecting to receive d
 
 The `input` block follows the syntax shown below:
 
-```nextflow
+[source,nextflow,linenums]
+----
 input:
   <input qualifier> <input name>
-```
+----
 
 === Input values
 
@@ -271,11 +272,12 @@ workflow {
 
 In the above example the process is executed three times, each time a value is received from the channel `num` and used to process the script. Thus, it results in an output similar to the one shown below:
 
-```
+[cmd]
+----
 process job 3
 process job 1
 process job 2
-```
+----
 
 IMPORTANT: The channel guarantees that items are delivered in the same order as they have been sent - but - since the process is executed in a parallel manner, there is no guarantee that they are processed in the same order as they are received.
 
@@ -528,7 +530,7 @@ workflow {
 .The output should look something like:
 [%collapsible]
 ====
-[source,nextflow,linenums]
+[cmd]
 ----
 1 and b
 1 and a
@@ -658,6 +660,7 @@ The _output_ declaration block defines the channels used by the process to send 
 
 Only one output block, that can contain one or more output declaration, can be defined. The output block follows the syntax shown below:
 
+[source,nextflow,linenums]
 ----
 output:
   <output qualifier> <output name> , emit: <output channel>
@@ -750,6 +753,7 @@ workflow {
 
 Prints the following:
 
+[cmd]
 ----
 File: chunk_aa => H
 File: chunk_ab => o
@@ -773,7 +777,7 @@ for the `flatMap` operator is available at https://www.nextflow.io/docs/latest/o
 .Click here for the answer:
 [%collapsible]
 ====
-[source,nextflow,linenums]
+[cmd]
 ----
 File: [chunk_aa, chunk_ab, chunk_ac, chunk_ad] => [H, o, l, a]
 ----

--- a/asciidocs/rnaseq_pipeline.adoc
+++ b/asciidocs/rnaseq_pipeline.adoc
@@ -168,7 +168,7 @@ Print the output of the `index_ch` channel by using the https://www.nextflow.io/
 ====
 Add the following to the end of your script file:
 
-[source,nextflow,linenums]
+[source,nextflow]
 ----
 index_ch.view()
 ----
@@ -205,7 +205,7 @@ Use the command `tree work` to see how Nextflow organizes the process work direc
 ====
 It should look something like this:
 
-[unix]
+[cmd]
 ----
 work
 ├── 17
@@ -352,9 +352,10 @@ Add a https://www.nextflow.io/docs/latest/process.html#tag[tag] directive to the
 [%collapsible]
 ====
 Add the following before the input declaration:
-```
+[source,nextflow]
+----
   tag "Salmon on $sample_id"
-```
+----
 ====
 
 [discrete]
@@ -367,9 +368,10 @@ to the `QUANTIFICATION` process to store the process results in a directory of y
 [%collapsible]
 ====
 Add the following before the `input` declaration in the `QUANTIFICATION` process:
-```
+[source,nextflow]
+----
   publishDir params.outdir, mode:'copy'
-```
+----
 ====
 
 [discrete]
@@ -487,7 +489,7 @@ fastqc -o fastqc_${sample_id}_logs -f fastq -q ${reads}
 
 Save it, give execute permission, and move it into the `bin` directory as shown below:
 
-[source,bash,linenums]
+[cmd,linenums]
 ----
 chmod +x fastqc.sh
 mkdir -p bin
@@ -507,6 +509,7 @@ the following code:
 
 Run it as before:
 
+[cmd]
 ----
 nextflow run script7.nf -resume --reads 'data/ggal/*_{1,2}.fq'
 ----
@@ -546,7 +549,7 @@ representation. Note: This feature requires the installation of http://www.graph
 See https://www.nextflow.io/docs/latest/tracing.html#dag-visualisation[here,window="_blank"] for further details.
 Then try running :
 
-[source]
+[cmd]
 ----
 dot -Tpng dag.dot > graph.png
 open graph.png

--- a/asciidocs/rnaseq_pipeline.adoc
+++ b/asciidocs/rnaseq_pipeline.adoc
@@ -28,11 +28,17 @@ println "reads: $params.reads"
 
 Run it by using the following command:
 
-  nextflow run script1.nf
+[cmd]
+----
+nextflow run script1.nf
+----
 
 Try to specify a different input parameter in your execution command, for example:
 
-  nextflow run script1.nf --reads '/workspace/nf-training-public/nf-training/data/ggal/lung_{1,2}.fq'
+[cmd]
+----
+nextflow run script1.nf --reads '/workspace/nf-training-public/nf-training/data/ggal/lung_{1,2}.fq'
+----
 
 [discrete]
 === Exercise
@@ -135,14 +141,20 @@ IMPORTANT: Resource requirements such as CPUs and memory limits can change with 
 
 Run it by using the command:
 
-  nextflow run script2.nf
+[cmd]
+----
+nextflow run script2.nf
+----
 
 The execution will fail because `salmon` is not installed in your environment.
 
 Add the command line option `-with-docker` to launch the execution through a Docker container,
 as shown below:
 
-  nextflow run script2.nf -with-docker
+[cmd]
+----
+nextflow run script2.nf -with-docker
+----
 
 This time the execution will work because it uses the Docker container `nextflow/rnaseq-nf` that is defined in the
 `nextflow.config` file in your current directory. If you are running this script locally then you will need to download docker
@@ -151,7 +163,10 @@ containing the run scripts. You can learn more about docker https://www.nextflow
 
 To avoid adding `-with-docker` each time you execute the script, add the following line to the `nextflow.config` file:
 
-  docker.enabled = true
+[source,config]
+----
+docker.enabled = true
+----
 
 [discrete]
 === Exercise
@@ -253,7 +268,10 @@ Edit the script `script3.nf` by adding the following statement as the last line 
 
 Save it and execute it with the following command:
 
-  nextflow run script3.nf
+[cmd]
+----
+nextflow run script3.nf
+----
 
 It will print something similar to this:
 
@@ -265,7 +283,10 @@ representing the actual files.
 
 Try it again specifying different read files by using a glob pattern:
 
-  nextflow run script3.nf --reads 'data/ggal/*_{1,2}.fq'
+[cmd]
+----
+nextflow run script3.nf --reads 'data/ggal/*_{1,2}.fq'
+----
 
 IMPORTANT: File paths that include one or more wildcards ie. `*`, `?`, etc., MUST be
 wrapped in single-quoted characters to avoid Bash expanding the glob.
@@ -326,7 +347,10 @@ Also, note that the second input channel for the `QUANTIFICATION` process, is th
 
 Execute it by using the following command:
 
-  nextflow run script4.nf -resume
+[cmd]
+----
+nextflow run script4.nf -resume
+----
 
 You will see the execution of the `QUANTIFICATION` process.
 
@@ -334,7 +358,10 @@ When using the `-resume` option, any step that has already been processed is ski
 
 Try to execute the same script again with more read files, as shown below:
 
-  nextflow run script4.nf -resume --reads 'data/ggal/*_{1,2}.fq'
+[cmd]
+----
+nextflow run script4.nf -resume --reads 'data/ggal/*_{1,2}.fq'
+----
 
 You will notice that the `QUANTIFICATION` process is executed multiple times.
 
@@ -391,7 +418,10 @@ Next, we implement a `FASTQC` quality control step for your input reads (using t
 
 You can run it by using the following command:
 
-  nextflow run script5.nf -resume
+[cmd]
+----
+nextflow run script5.nf -resume
+----
 
 Nextflow DSL2 knows to split the `reads_pair_ch` into two identical channels as they are required twice as an input for both of the `FASTQC` and the `QUANTIFICATION` process.
 
@@ -403,7 +433,10 @@ a final report using the http://multiqc.info/[MultiQC] tool.
 
 Execute the next script with the following command:
 
-  nextflow run script6.nf -resume --reads 'data/ggal/*_{1,2}.fq'
+[cmd]
+----
+nextflow run script6.nf -resume --reads 'data/ggal/*_{1,2}.fq'
+----
 
 It creates the final report in the `results` folder in the current `work` directory.
 
@@ -438,7 +471,10 @@ when the script completes.
 
 Try to run it by using the following command:
 
-  nextflow run script7.nf -resume --reads 'data/ggal/*_{1,2}.fq'
+[cmd]
+----
+nextflow run script7.nf -resume --reads 'data/ggal/*_{1,2}.fq'
+----
 
 == Email notifications
 
@@ -530,7 +566,10 @@ Nextflow can produce multiple reports and charts providing several runtime metri
 Run the https://github.com/nextflow-io/rnaseq-nf[rnaseq-nf,window="_blank"] pipeline
 previously introduced as shown below:
 
-  nextflow run rnaseq-nf -with-docker -with-report -with-trace -with-timeline -with-dag dag.png
+[cmd]
+----
+nextflow run rnaseq-nf -with-docker -with-report -with-trace -with-timeline -with-dag dag.png
+----
 
 The `-with-docker` option launches each task of the execution as a Docker container run command.
 
@@ -572,18 +611,27 @@ https://github.com/nextflow-io/rnaseq-nf
 
 You can run it by specifying the project name and launching each task of the execution as a Docker container run command:
 
-  nextflow run nextflow-io/rnaseq-nf -with-docker
+[cmd]
+----
+nextflow run nextflow-io/rnaseq-nf -with-docker
+----
 
 It automatically downloads the container and stores it in the `$HOME/.nextflow` folder.
 
 
 Use the command `info` to show the project information:
 
-  nextflow info nextflow-io/rnaseq-nf
+[cmd]
+----
+nextflow info nextflow-io/rnaseq-nf
+----
 
 Nextflow allows the execution of a specific revision of your project by using the `-r` command line option. For example:
 
-  nextflow run nextflow-io/rnaseq-nf -r dev
+[cmd]
+----
+nextflow run nextflow-io/rnaseq-nf -r dev
+----
 
 Revision are defined by using Git tags or branches defined in the project repository.
 

--- a/asciidocs/rnaseq_pipeline.adoc
+++ b/asciidocs/rnaseq_pipeline.adoc
@@ -264,7 +264,10 @@ This step shows how to match *read* files into pairs, so they can be mapped by *
 
 Edit the script `script3.nf` by adding the following statement as the last line in the workflow scope:
 
-  read_pairs_ch.view()
+[source,nextflow]
+----
+read_pairs_ch.view()
+----
 
 Save it and execute it with the following command:
 
@@ -275,7 +278,10 @@ nextflow run script3.nf
 
 It will print something similar to this:
 
-  [gut, [/.../data/ggal/gut_1.fq, /.../data/ggal/gut_2.fq]]
+[cmd]
+----
+[gut, [/.../data/ggal/gut_1.fq, /.../data/ggal/gut_2.fq]]
+----
 
 The above example shows how the `read_pairs_ch` channel emits tuples composed of
 two elements, where the first is the read pair prefix and the second is a list
@@ -381,7 +387,7 @@ Add a https://www.nextflow.io/docs/latest/process.html#tag[tag] directive to the
 Add the following before the input declaration:
 [source,nextflow]
 ----
-  tag "Salmon on $sample_id"
+tag "Salmon on $sample_id"
 ----
 ====
 
@@ -397,7 +403,7 @@ to the `QUANTIFICATION` process to store the process results in a directory of y
 Add the following before the `input` declaration in the `QUANTIFICATION` process:
 [source,nextflow]
 ----
-  publishDir params.outdir, mode:'copy'
+publishDir params.outdir, mode:'copy'
 ----
 ====
 
@@ -444,7 +450,10 @@ In this script, note the use of the https://www.nextflow.io/docs/latest/operator
 and https://www.nextflow.io/docs/latest/operator.html#collect[collect,window="_blank"] operators chained
 together to gather the outputs of the `QUANTIFICATION` and `FASTQC` processes as a single input. https://www.nextflow.io/docs/latest/operator.html[Operators] can be used to combine and transform channels.
 
-  MULTIQC(quant_ch.mix(fastqc_ch).collect())
+[source,nextflow]
+----
+MULTIQC(quant_ch.mix(fastqc_ch).collect())
+----
 
 We only want one task of MultiQC to be executed to produce one report. Therefore, we use the `mix` channel operator to combine the two channels followed by the `collect` operator, to return the complete channel contents as a single element.
 
@@ -537,10 +546,10 @@ the following code:
 
 [source,nextflow,linenums]
 ----
-  script:
-  """
-  fastqc.sh "$sample_id" "$reads"
-  """
+script:
+"""
+fastqc.sh "$sample_id" "$reads"
+"""
 ----
 
 Run it as before:

--- a/asciidocs/setup.adoc
+++ b/asciidocs/setup.adoc
@@ -30,18 +30,21 @@ Nextflow can be used on any POSIX-compatible system (Linux, OS X, Windows Subsys
 
 Enter this command in your terminal:
 
+[cmd]
 ----
 wget -qO- https://get.nextflow.io | bash
 ----
 
 Or, if you prefer curl:
 
+[cmd]
 ----
 curl -s https://get.nextflow.io | bash
 ----
 
 Then ensure that the downloaded binary is executable:
 
+[cmd]
 ----
 chmod +x nextflow
 ----
@@ -64,7 +67,7 @@ Then `cd` into the `nf-training` directory
 
 Check the correct installation of `nextflow` by running the following command:
 
-[source,bash,linenums]
+[cmd]
 ----
 nextflow info
 ----
@@ -113,7 +116,7 @@ To test that the environment is working correctly, type the following into the t
 
 This should come up with the Nextflow version and runtime information:
 
-[source,bash]
+[cmd,linenums]
 ----
   Version: 22.04.2 build 5701
   Created: 16-05-2022 17:52 UTC
@@ -161,7 +164,7 @@ It is worth checking out the latest releases on github https://github.com/nextfl
 
 If you want or need to use a specific version of Nextflow, you can set the NXF_VER variable as shown below:
 
-[source,bash,linenums]
+[cmd]
 ----
 export NXF_VER=21.10.0
 ----

--- a/asciidocs/tower.adoc
+++ b/asciidocs/tower.adoc
@@ -45,7 +45,7 @@ image::usage_token.png[]
 
 Once your token has been created, open a terminal and type:
 
-[source,bash,linenums]
+[cmd]
 ----
 export TOWER_ACCESS_TOKEN=eyxxxxxxxxxxxxxxxQ1ZTE=
 export NXF_VER=20.10.0
@@ -57,7 +57,7 @@ NOTE: Check your `nextflow -version`. Bearer tokens require Nextflow version 20.
 
 To submit a pipeline to a https://help.tower.nf/getting-started/workspace/[Workspace] using the Nextflow command-line tool, add the workspace ID to your environment. For example:
 
-[source,bash,linenums]
+[cmd]
 ----
 export TOWER_WORKSPACE_ID=000000000000000
 ----
@@ -177,8 +177,8 @@ See the Nextflow https://www.nextflow.io/docs/latest/config.html#config-profiles
 +
 [source, yaml, linenums]
 ----
-    reads: 's3://nf-bucket/exome-data/ERR013140_{1,2}.fastq.bz2'
-    paired_end: true
+reads: 's3://nf-bucket/exome-data/ERR013140_{1,2}.fastq.bz2'
+paired_end: true
 ----
 +
 8. Select Launchpad to begin the pipeline execution.

--- a/nf-training/script2.nf
+++ b/nf-training/script2.nf
@@ -7,29 +7,29 @@ params.multiqc = "$projectDir/multiqc"
 params.outdir = "results"
 
 log.info """\
-    R N A S E Q - N F   P I P E L I N E   
+    R N A S E Q - N F   P I P E L I N E
     ===================================
     transcriptome: ${params.transcriptome_file}
     reads        : ${params.reads}
     outdir       : ${params.outdir}
     """
     .stripIndent()
-        
-/* 
- * define the `index` process that creates a binary index 
+
+/*
+ * define the `index` process that creates a binary index
  * given the transcriptome file
  */
 process INDEX {
     input:
     path transcriptome
-    
+
     output:
     path 'salmon_index'
 
-    script: 
+    script:
     """
     salmon index --threads $task.cpus -t $transcriptome -i salmon_index
-    """  
+    """
 }
 
 workflow {

--- a/nf-training/script3.nf
+++ b/nf-training/script3.nf
@@ -7,12 +7,12 @@ params.multiqc = "$projectDir/multiqc"
 params.outdir = "results"
 
 log.info """\
-        R N A S E Q - N F   P I P E L I N E   
+        R N A S E Q - N F   P I P E L I N E
         ===================================
         transcriptome: ${params.transcriptome_file}
         reads        : ${params.reads}
         outdir       : ${params.outdir}
         """
         .stripIndent()
-        
+
 read_pairs_ch = Channel.fromFilePairs(params.reads)

--- a/nf-training/script4.nf
+++ b/nf-training/script4.nf
@@ -7,7 +7,7 @@ params.multiqc = "$projectDir/multiqc"
 params.outdir = "results"
 
 log.info """\
-    R N A S E Q - N F   P I P E L I N E   
+    R N A S E Q - N F   P I P E L I N E
     ===================================
     transcriptome: ${params.transcriptome_file}
     reads        : ${params.reads}
@@ -15,18 +15,18 @@ log.info """\
     """
     .stripIndent()
 
-/* 
- * define the `index` process that creates a binary index 
+/*
+ * define the `index` process that creates a binary index
  * given the transcriptome file
  */
 process INDEX {
     input:
     path transcriptome
-    
+
     output:
     path 'salmon_index'
 
-    script: 
+    script:
     """
     salmon index --threads $task.cpus -t $transcriptome -i salmon_index
     """
@@ -50,7 +50,7 @@ workflow {
     Channel
         .fromFilePairs(params.reads, checkIfExists: true)
         .set { read_pairs_ch }
-        
+
     index_ch = INDEX(params.transcriptome_file)
     quant_ch = QUANTIFICATION(index_ch, read_pairs_ch)
 }

--- a/nf-training/script5.nf
+++ b/nf-training/script5.nf
@@ -7,7 +7,7 @@ params.multiqc = "$projectDir/multiqc"
 params.outdir = "results"
 
 log.info """\
-    R N A S E Q - N F   P I P E L I N E   
+    R N A S E Q - N F   P I P E L I N E
     ===================================
     transcriptome: ${params.transcriptome_file}
     reads        : ${params.reads}
@@ -15,18 +15,18 @@ log.info """\
     """
     .stripIndent()
 
-/* 
- * define the `index` process that creates a binary index 
+/*
+ * define the `index` process that creates a binary index
  * given the transcriptome file
  */
 process INDEX {
     input:
     path transcriptome
-    
+
     output:
     path 'salmon_index'
 
-    script: 
+    script:
     """
     salmon index --threads $task.cpus -t $transcriptome -i salmon_index
     """
@@ -35,7 +35,7 @@ process INDEX {
 process QUANTIFICATION {
     tag "Salmon on $sample_id"
     publishDir params.outdir, mode:'copy'
-    
+
     input:
     path salmon_index
     tuple val(sample_id), path(reads)
@@ -69,8 +69,8 @@ workflow {
     Channel
         .fromFilePairs(params.reads, checkIfExists: true)
         .set { read_pairs_ch }
-        
+
     index_ch = INDEX(params.transcriptome_file)
     quant_ch = QUANTIFICATION(index_ch, read_pairs_ch)
-    fastqc_ch = FASTQC(read_pairs_ch) 
+    fastqc_ch = FASTQC(read_pairs_ch)
 }

--- a/nf-training/script6.nf
+++ b/nf-training/script6.nf
@@ -7,7 +7,7 @@ params.multiqc = "$projectDir/multiqc"
 params.outdir = "results"
 
 log.info """\
-    R N A S E Q - N F   P I P E L I N E   
+    R N A S E Q - N F   P I P E L I N E
     ===================================
     transcriptome: ${params.transcriptome_file}
     reads        : ${params.reads}
@@ -15,8 +15,8 @@ log.info """\
     """
     .stripIndent()
 
-/* 
- * define the `index` process that creates a binary index 
+/*
+ * define the `index` process that creates a binary index
  * given the transcriptome file
  */
 process INDEX {
@@ -26,7 +26,7 @@ process INDEX {
     output:
     path 'salmon_index'
 
-    script: 
+    script:
     """
     salmon index --threads $task.cpus -t $transcriptome -i salmon_index
     """
@@ -67,26 +67,26 @@ process FASTQC {
 
 process MULTIQC {
     publishDir params.outdir, mode:'copy'
-    
+
     input:
     path '*'
-    
+
     output:
     path 'multiqc_report.html'
-    
+
     script:
     """
-    multiqc . 
+    multiqc .
     """
-} 
+}
 
 workflow {
     Channel
         .fromFilePairs(params.reads, checkIfExists: true)
         .set { read_pairs_ch }
-        
+
     index_ch = INDEX(params.transcriptome_file)
     quant_ch = QUANTIFICATION(index_ch, read_pairs_ch)
-    fastqc_ch = FASTQC(read_pairs_ch) 
+    fastqc_ch = FASTQC(read_pairs_ch)
     MULTIQC(quant_ch.mix(fastqc_ch).collect())
 }

--- a/nf-training/script7.nf
+++ b/nf-training/script7.nf
@@ -6,7 +6,7 @@ params.transcriptome_file = "$projectDir/data/ggal/transcriptome.fa"
 params.multiqc = "$projectDir/multiqc"
 params.outdir = "results"
 log.info """\
-    R N A S E Q - N F   P I P E L I N E   
+    R N A S E Q - N F   P I P E L I N E
     ===================================
     transcriptome: ${params.transcriptome_file}
     reads        : ${params.reads}
@@ -14,8 +14,8 @@ log.info """\
     """
     .stripIndent()
 
-/* 
- * define the `index` process that creates a binary index 
+/*
+ * define the `index` process that creates a binary index
  * given the transcriptome file
  */
 process INDEX {
@@ -25,7 +25,7 @@ process INDEX {
     output:
     path 'salmon_index'
 
-    script: 
+    script:
     """
     salmon index --threads $task.cpus -t $transcriptome -i salmon_index
     """
@@ -69,24 +69,24 @@ process MULTIQC {
 
     input:
     path '*'
-    
+
     output:
     path 'multiqc_report.html'
 
     script:
     """
-    multiqc . 
-    """  
-} 
+    multiqc .
+    """
+}
 
 workflow {
     Channel
         .fromFilePairs(params.reads, checkIfExists: true)
         .set { read_pairs_ch }
-        
+
     index_ch = INDEX(params.transcriptome_file)
     quant_ch = QUANTIFICATION(index_ch, read_pairs_ch)
-    fastqc_ch = FASTQC(read_pairs_ch) 
+    fastqc_ch = FASTQC(read_pairs_ch)
     MULTIQC(quant_ch.mix(fastqc_ch).collect())
 }
 


### PR DESCRIPTION
This Pull Request consists of:

- [x] Remove trailing white spaces from script files (script1-7.nf)
- [x] Fix/standardize source code / output boxes
  - [x] Command lines should be of CMD type, not BASH
  - [x] All code boxes should have the language set, if applicable
  - [x] One line code boxes shouldn’t have line numbers
  - [x] Boxes with 2 or more lines should always have numbered lines (`linenums`)
  - [x] Output from commands shouldn’t be bash. They should be CMD.
  - [x] Standardize the code blocks
Most of the training code blocks consisted of 4 dashes with [keywords,in,this,format]. Some other times, it used ``` or just indentation.
  - [x] There is a snippet in text format, instead of code block (Section 5.2.9)
- [x] Last check for snippets I failed to see at the first time