### PR TITLE
Equal sign for directives only in config files

### DIFF
--- a/asciidocs/containers.adoc
+++ b/asciidocs/containers.adoc
@@ -617,7 +617,7 @@ with the following container directives for each process:
 [source,nextflow,linenums]
 ----
 process FASTQC {
-    container = 'biocontainers/fastqc:v0.11.5'
+    container 'biocontainers/fastqc:v0.11.5'
     tag "FASTQC on $sample_id"
 ...
 ----
@@ -628,7 +628,7 @@ and
 ----
 process QUANTIFICATION {
     tag "Salmon on $sample_id"
-    container = 'quay.io/biocontainers/salmon:1.7.0--h84f40af_0'
+    container 'quay.io/biocontainers/salmon:1.7.0--h84f40af_0'
     publishDir params.outdir, mode:'copy'
 ...
 ----


### PR DESCRIPTION
Most of it has been fixed in the past but these two examples remained.
container = 'nextflow-io/rnaseq-nf' when within nextflow.config
container 'nextflow-io/rnaseq-nf' when within script files
