### PR TITLE
Use fork for numbered headings to fix hands-on numbering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,3 +70,7 @@ There are a couple of known limitations that I haven't figured out how to get ar
 ### Code annotations
 
 Mkdocs Material uses `// code comments` to anchor the annotations. That's great, until you want an annotation in the middle of a large multi-line string (say, like a `script` block).
+
+## TODO / FIXME
+
+-   Remove hack in `requirements.txt` when [this PR](https://github.com/timvink/mkdocs-enumerate-headings-plugin/pull/33) is merged

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,9 +114,8 @@ plugins:
               fill: "#27AE60"
               text: "#FFFFFF"
     - enumerate-headings:
-          # Requires: https://github.com/timvink/mkdocs-enumerate-headings-plugin/pull/33
-          # restart_increment_after:
-          #    - hands_on/01_datasets.md
+          restart_increment_after:
+              - hands_on/01_datasets.md
           exclude:
               - index.md
               - help.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ mkdocs-material
 pymdown-extensions
 pillow
 cairosvg
-mkdocs-enumerate-headings-plugin
+git+https://github.com/ewels/mkdocs-enumerate-headings-plugin@master#egg=mkdocs-enumerate-headings-plugin


### PR DESCRIPTION
Just until https://github.com/timvink/mkdocs-enumerate-headings-plugin/pull/33 is merged